### PR TITLE
Update xattr to use utf-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.AppleDouble/
+.pc/
+PKG-INFO
+debian/
+ez_setup/
+xattr.egg-info/
+build/

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,8 @@ xattr is a Python wrapper for Darwin's extended filesystem attributes
 
 Extended attributes extend the basic attributes of files and directories
 in the file system.  They are stored as name:data pairs associated with
-file system objects (files, directories, symlinks, etc).
+file system objects (files, directories, symlinks, etc), where data
+is a string encoded as utf-8.
 
 Extended attributes are currently only available on Darwin 8.0 and later.
 This corresponds to Mac OS X 10.4 (Tiger).

--- a/xattr/__init__.py
+++ b/xattr/__init__.py
@@ -76,7 +76,7 @@ class xattr(object):
 
     def get(self, name, options=0):
         """
-        Retrieve the extended attribute ``name`` as a ``str``.
+        Retrieve the extended attribute ``name`` as a ``unicode`` string.
         Raises ``IOError`` on failure.
 
         See x-man-page://2/getxattr for options and possible errors.
@@ -85,7 +85,7 @@ class xattr(object):
 
     def set(self, name, value, options=0):
         """
-        Set the extended attribute ``name`` to ``value``
+        Set the extended attribute ``name`` to ``value`` encoded as utf-8
         Raises ``IOError`` on failure.
 
         See x-man-page://2/setxattr for options and possible errors.


### PR DESCRIPTION
Hi,

I have updated the code to store values as utf-8 and to return them as unicode strings. I have tested on Linux (hence the debian stuff in .gitignore).

Thought this might be of wider interest, as I've seen a few people on the web doing a reload(sys), sys.setdefaultencoding('utf-8') just to be able to save unicode in extended attribues.

Sorry about the whitespace issues in the diff listing; I'm a bit new to this git lark.

Regards,
Ingvar
