### PR TITLE
Fix error: missing binary operator before token "("

### DIFF
--- a/xattr/_xattr.c
+++ b/xattr/_xattr.c
@@ -232,7 +232,7 @@ static ssize_t xattr_flistxattr(int fd, char *namebuf, size_t size, int options)
     return rv;
 }
 
-#elif defined(__SUN__) || defined(__sun__) || define(sun)
+#elif defined(__SUN__) || defined(__sun__) || defined(sun)
 
 /* Solaris 9 and later compatibility API */
 #define XATTR_XATTR_NOFOLLOW 0x0001


### PR DESCRIPTION
There is a compilation error when I installed xattr:

```
xattr/_xattr.c:235:53: error: missing binary operator before token "("
```

And I found that line 235 of xattr/_xattr.c

``` c
#elif defined(__SUN__) || defined(__sun__) || define(sun)
```

should be

``` c
#elif defined(__SUN__) || defined(__sun__) || defined(sun)
```

The last **define** should be **defined**.
After fixing it, xattr could be installed correctly.
