### PR TITLE
Add Python 3 support marker in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ Operating System :: MacOS :: MacOS X
 Operating System :: POSIX :: Linux
 Operating System :: POSIX :: BSD :: FreeBSD
 Programming Language :: Python
+Programming Language :: Python :: 2
+Programming Language :: Python :: 3
 Topic :: Software Development :: Libraries :: Python Modules
 """.splitlines()))
 


### PR DESCRIPTION
With the new markers, it's clear to PyPi users that xattr works both on Python 2 and 3.
This should be sufficient for xattr to show in green on the [Python 3 Wall of Superpowers](http://python3wos.appspot.com/).
