### PR TITLE
Python3 rework: replace unicode() with str.decode()

### DIFF
--- a/xattr/__init__.py
+++ b/xattr/__init__.py
@@ -89,13 +89,13 @@ class xattr(object):
     def list(self, options=0):
         """
         Retrieves the extended attributes currently set as a list
-        of unicode strings.  Raises ``IOError`` on failure.
+        of strings.  Raises ``IOError`` on failure.
 
         See x-man-page://2/listxattr for options and possible errors.
         """
         res = self._call(_listxattr, _flistxattr, options | self.options).split(b'\x00')
         res.pop()
-        return [unicode(s, 'utf-8') for s in res]
+        return [s.decode('utf-8') for s in res]
 
     # dict-like methods
 


### PR DESCRIPTION
`xattr.listxattr()` does not work in Python3 because the builtin function `unicode()` was removed.
Solution: replace `unicode()` with `str.decode()`.
