### PR TITLE
Python3 support takes a lot of reps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 *.pyc
 *.so
 .\#*
+*~
+*.bak
 __pycache__

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ Extended attributes are currently only available on Darwin 8.0+ (Mac OS X 10.4)
 and Linux 2.6+. Experimental support is included for Solaris and FreeBSD.
 """
 
-CLASSIFIERS = filter(bool, map(str.strip,
+CLASSIFIERS = list(filter(bool, list(map(str.strip,
 """
 Environment :: Console
 Intended Audience :: Developers
@@ -40,7 +40,7 @@ Programming Language :: Python
 Programming Language :: Python :: 2
 Programming Language :: Python :: 3
 Topic :: Software Development :: Libraries :: Python Modules
-""".splitlines()))
+""".splitlines()))))
 
 setup(
     name="xattr",

--- a/xattr/__init__.py
+++ b/xattr/__init__.py
@@ -133,17 +133,17 @@ class xattr(object):
     __contains__ = has_key
 
     def clear(self):
-        for k in self.keys():
+        for k in list(self.keys()):
             del self[k]
 
     def update(self, seq):
         if not hasattr(seq, 'iteritems'):
             seq = dict(seq)
-        for k, v in seq.iteritems():
+        for k, v in seq.items():
             self[k] = v
 
     def copy(self):
-        return dict(self.iteritems())
+        return dict(iter(self.items()))
 
     def setdefault(self, k, d=''):
         try:
@@ -156,18 +156,18 @@ class xattr(object):
         return self.list()
 
     def itervalues(self):
-        for k, v in self.iteritems():
+        for k, v in self.items():
             yield v
 
     def values(self):
-        return list(self.itervalues())
+        return list(self.values())
 
     def iteritems(self):
         for k in self.list():
             yield k, self.get(k)
 
     def items(self):
-        return list(self.iteritems())
+        return list(self.items())
 
 
 def listxattr(f, symlink=False):

--- a/xattr/tests/test_xattr.py
+++ b/xattr/tests/test_xattr.py
@@ -9,29 +9,29 @@ import xattr
 class BaseTestXattr(object):
     def test_attr(self):
         x = xattr.xattr(self.tempfile)
-        self.assertEqual(x.keys(), [])
+        self.assertEqual(list(x.keys()), [])
         self.assertEqual(x.list(), [])
         self.assertEqual(dict(x), {})
 
         x['user.sopal'] = b'foo'
         x['user.sop.foo'] = b'bar'
-        x[u'user.\N{SNOWMAN}'] = b'not a snowman'
+        x['user.\N{SNOWMAN}'] = b'not a snowman'
         del x
 
         x = xattr.xattr(self.tempfile)
         attrs = set(x.list())
         self.assertTrue('user.sopal' in x)
-        self.assertTrue(u'user.sopal' in attrs)
+        self.assertTrue('user.sopal' in attrs)
         self.assertEqual(x['user.sopal'], b'foo')
         self.assertTrue('user.sop.foo' in x)
-        self.assertTrue(u'user.sop.foo' in attrs)
+        self.assertTrue('user.sop.foo' in attrs)
         self.assertEqual(x['user.sop.foo'], b'bar')
-        self.assertTrue(u'user.\N{SNOWMAN}' in x)
-        self.assertTrue(u'user.\N{SNOWMAN}' in attrs)
-        self.assertEqual(x[u'user.\N{SNOWMAN}'],
+        self.assertTrue('user.\N{SNOWMAN}' in x)
+        self.assertTrue('user.\N{SNOWMAN}' in attrs)
+        self.assertEqual(x['user.\N{SNOWMAN}'],
                          b'not a snowman')
 
-        del x[u'user.\N{SNOWMAN}']
+        del x['user.\N{SNOWMAN}']
         del x['user.sop.foo']
         del x
 
@@ -41,7 +41,7 @@ class BaseTestXattr(object):
     def test_setxattr_unicode_error(self):
         x = xattr.xattr(self.tempfile)
         with self.assertRaises(TypeError) as exc_info:
-            x['abc'] = u'abc'
+            x['abc'] = 'abc'
         if sys.version_info[0] >= 3:
             msg = "Value must be bytes, str was passed."
         else:

--- a/xattr/tool.py
+++ b/xattr/tool.py
@@ -25,7 +25,7 @@
 # IN THE SOFTWARE.
 ##
 
-from __future__ import print_function
+
 
 import sys
 import os
@@ -71,7 +71,7 @@ _FILTER = ''.join([(len(repr(chr(x))) == 3) and chr(x) or '.' for x in range(256
 
 def _dump(src, length=16):
     result = []
-    for i in xrange(0, len(src), length):
+    for i in range(0, len(src), length):
         s = src[i:i+length]
         hexa = ' '.join(["%02X" % ord(x) for x in s])
         printable = s.translate(_FILTER)
@@ -169,7 +169,7 @@ def main():
                 if read:
                     attr_names = (attr_name,)
                 else:
-                    attr_names = attrs.keys()
+                    attr_names = list(attrs.keys())
             except (IOError, OSError) as e:
                 onError(e)
                 continue


### PR DESCRIPTION
Python3 is totally awesome, like you must use it now. After I got the Pump tonight I sat with Lou Ferrigno in Gold's cybercafe and I said to hum "Hey Lou, what version of python are you using?" and he said 2.7.5 and I laughed at him it was funny. "Lou, you are dumb, don't you know that 3.3 is the shit now? Dabeaz even said so on his blog."

So as I was saying, xattr now works with python 3.3 which is what dabeaz and the rest of us pros are using. Here is the pull request that must merge. Do it now! Also, why is your travis config all strange? That's ok, we can pump it up later. Hasta la vista!
