### PR TITLE
bug 28: solaris & solaris studio compiler support

### DIFF
--- a/xattr/lib.py
+++ b/xattr/lib.py
@@ -29,12 +29,13 @@ lib = ffi.verify("""
 #include "Python.h"
 #ifdef __FreeBSD__
 #include <sys/extattr.h>
-#elif defined(__SUN__) || defined(__sun__) || defined(sun)
+#elif defined(__SUN__) || defined(__sun__) || defined(__sun)
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <alloca.h>
 #else
 #include <sys/xattr.h>
 #endif
@@ -59,7 +60,7 @@ static void convert_bsd_list(char *namebuf, size_t size)
     while(offset < size) {
         int length = (int) namebuf[offset];
         memmove(namebuf+offset, namebuf+offset+1, length);
-        namebuf[offset+length] = '\0';
+        namebuf[offset+length] = '\\0';
         offset += length+1;
     }
 }
@@ -260,13 +261,16 @@ static ssize_t xattr_flistxattr(int fd, char *namebuf, size_t size, int options)
     return rv;
 }
 
-#elif defined(__SUN__) || defined(__sun__) || defined(sun)
+#elif defined(__SUN__) || defined(__sun__) || defined(__sun)
 
 /* Solaris 9 and later compatibility API */
 #define XATTR_XATTR_NOFOLLOW 0x0001
 #define XATTR_XATTR_CREATE 0x0002
 #define XATTR_XATTR_REPLACE 0x0004
 #define XATTR_XATTR_NOSECURITY 0x0008
+
+#define XATTR_CREATE 0x1
+#define XATTR_REPLACE 0x2
 
 #ifndef u_int32_t
 #define u_int32_t uint32_t
@@ -429,7 +433,7 @@ static ssize_t xattr_xflistxattr(int xfd, char *namebuf, size_t size, int option
             snprintf((char *)(namebuf + nsize), esize + 1,
                     entry->d_name);
         }
-        nsize += esize + 1; /* +1 for \0 */
+        nsize += esize + 1; /* +1 for \\0 */
     }
     closedir(dirp);
     return nsize;
@@ -438,7 +442,7 @@ static ssize_t xattr_flistxattr(int fd, char *namebuf, size_t size, int options)
 {
     int xfd;
 
-    xfd = openat(fd, ".", O_RDONLY);
+    xfd = openat(fd, ".", O_RDONLY | O_XATTR);
     return xattr_xflistxattr(xfd, namebuf, size, options);
 }
 
@@ -725,7 +729,7 @@ def _flistxattr(fd, options=0):
     flistxattr(fd, options=0) -> str
     """
     res = lib.xattr_flistxattr(fd, ffi.NULL, 0, options)
-    if res == 1:
+    if res == -1:
         raise error()
     buf = ffi.new("char[]", res)
     res = lib.xattr_flistxattr(fd, buf, res, options)


### PR DESCRIPTION
In addition to the notes in #28, when rebasing my changes to 0.7.5, I had to change test_setxattr_unicode_error() to work with Python 2.6.
