### PR TITLE
Assure that attribute name starts with a valid prefix.

### DIFF
--- a/xattr/tests/test_xattr.py
+++ b/xattr/tests/test_xattr.py
@@ -78,6 +78,16 @@ class BaseTestXattr(object):
             self.assertEqual(symlink['user.islink'], b'true')
         finally:
             os.remove(symlinkPath)
+    
+    def test_bad_name_prefix(self):
+        xfile = xattr.xattr(self.tempfile)
+        xfile['testing'] = b'fail'
+        self.assertEqual('testing' not in xfile)
+
+    def test_good_name_prefix(self):
+        xfile = xattr.xattr(self.tempfile)
+        xfile['user.testing'] = b'pass'
+        self.assertEqual('user.testing' in xfile)
 
 
 class TestFile(TestCase, BaseTestXattr):

--- a/xattr/tool.py
+++ b/xattr/tool.py
@@ -122,6 +122,11 @@ def main():
     if read or write or delete:
         if not args:
             usage("No attr_name")
+        # Doublecheck prefixes
+        ok_prefixes = ["user", "system", "trusted", "security"]
+        split = args[1].split('.')
+        if len(split) < 2 and split[0] not in ok_prefixes:
+            usage("Name must start with \"{0}.\"".format(ok_prefixes))
         attr_name = args.pop(0)
 
     if write:


### PR DESCRIPTION
Took me 3 hours to figure out that I needed to prefix my xattr -w 'attribute name' with something like "user," "system," "trusted," "security." This issue came up in my Ubuntu 14.04, but I had no problem with Mac OSX 10.9.

I'd like to propose that for consistency's sake (across platforms), prefixes should be checked. Otherwise, it could be more helpful to produce a more descriptive error message. The system typically returns an "[Errno 95] This operation is not supported."