### PR TITLE
more compatibility with pyxattr for bup

### DIFF
--- a/xattr/__init__.py
+++ b/xattr/__init__.py
@@ -162,12 +162,12 @@ class xattr(object):
     def values(self):
         return list(self.itervalues())
 
-    def iteritems(self):
-        for k in self.list():
+    def iteritems(self, options=0):
+        for k in self.list(options=options):
             yield k, self.get(k)
 
-    def items(self):
-        return list(self.iteritems())
+    def items(self, options=0):
+        return list(self.iteritems(options=options))
 
 
 def listxattr(f, symlink=False):

--- a/xattr/__init__.py
+++ b/xattr/__init__.py
@@ -160,14 +160,14 @@ class xattr(object):
             yield v
 
     def values(self):
-        return list(self.itervalues())
+        return _pylist(self.itervalues())
 
     def iteritems(self, options=0):
         for k in self.list(options=options):
             yield k, self.get(k)
 
     def items(self, options=0):
-        return list(self.iteritems(options=options))
+        return _pylist(self.iteritems(options=options))
 
 
 def listxattr(f, symlink=False, nofollow=False):
@@ -185,6 +185,13 @@ def get_all(f, symlink=False, nofollow=False):
     symlink = symlink or nofollow
     options = symlink and XATTR_NOFOLLOW or 0
     return xattr(f).items(options=options)
+
+# XXX: This is really ugly - now we cannot use the standard python
+#      list() anymore in this module!
+_pylist = list
+def list(f, symlink=False, nofollow=False):
+    symlink = symlink or nofollow
+    return xattr(f).list(options=symlink and XATTR_NOFOLLOW or 0)
 
 def setxattr(f, attr, value, options=0, symlink=False, nofollow=False):
     if symlink or nofollow:

--- a/xattr/__init__.py
+++ b/xattr/__init__.py
@@ -179,14 +179,18 @@ def getxattr(f, attr, symlink=False, nofollow=False):
     symlink = symlink or nofollow
     return xattr(f).get(attr, options=symlink and XATTR_NOFOLLOW or 0)
 
+get = getxattr
 
 def setxattr(f, attr, value, options=0, symlink=False, nofollow=False):
     if symlink or nofollow:
         options |= XATTR_NOFOLLOW
     return xattr(f).set(attr, value, options=options)
 
+set = setxattr
 
 def removexattr(f, attr, symlink=False, nofollow=False):
     symlink = symlink or nofollow
     options = symlink and XATTR_NOFOLLOW or 0
     return xattr(f).remove(attr, options=options)
+
+remove = removexattr

--- a/xattr/__init__.py
+++ b/xattr/__init__.py
@@ -170,20 +170,23 @@ class xattr(object):
         return list(self.iteritems(options=options))
 
 
-def listxattr(f, symlink=False):
+def listxattr(f, symlink=False, nofollow=False):
+    symlink = symlink or nofollow
     return tuple(xattr(f).list(options=symlink and XATTR_NOFOLLOW or 0))
 
 
-def getxattr(f, attr, symlink=False):
+def getxattr(f, attr, symlink=False, nofollow=False):
+    symlink = symlink or nofollow
     return xattr(f).get(attr, options=symlink and XATTR_NOFOLLOW or 0)
 
 
-def setxattr(f, attr, value, options=0, symlink=False):
-    if symlink:
+def setxattr(f, attr, value, options=0, symlink=False, nofollow=False):
+    if symlink or nofollow:
         options |= XATTR_NOFOLLOW
     return xattr(f).set(attr, value, options=options)
 
 
-def removexattr(f, attr, symlink=False):
+def removexattr(f, attr, symlink=False, nofollow=False):
+    symlink = symlink or nofollow
     options = symlink and XATTR_NOFOLLOW or 0
     return xattr(f).remove(attr, options=options)

--- a/xattr/__init__.py
+++ b/xattr/__init__.py
@@ -181,6 +181,11 @@ def getxattr(f, attr, symlink=False, nofollow=False):
 
 get = getxattr
 
+def get_all(f, symlink=False, nofollow=False):
+    symlink = symlink or nofollow
+    options = symlink and XATTR_NOFOLLOW or 0
+    return xattr(f).items(options=options)
+
 def setxattr(f, attr, value, options=0, symlink=False, nofollow=False):
     if symlink or nofollow:
         options |= XATTR_NOFOLLOW


### PR DESCRIPTION
With this code, I can pass the bup test suite with xattr instead of pyxattr.

The list() functions is very ugly but actually used there, so there isn't any choice if it should be API compatible (and otherwise the whole point of this pull request is moot.)