### PR TITLE
Use surrogate handling identical to recent python's os.fsencode

### DIFF
--- a/xattr/lib.py
+++ b/xattr/lib.py
@@ -606,18 +606,20 @@ XATTR_MAXNAMELEN = lib.XATTR_MAXNAMELEN
 XATTR_FINDERINFO_NAME = "com.apple.FinderInfo"
 XATTR_RESOURCEFORK_NAME = "com.apple.ResourceFork"
 
+try:
+    fs_encode = os.fsencode
+except AttributeError:
+    def fs_encode(val):
+        encoding = sys.getfilesystemencoding()
+        if encoding == 'mbcs':
+            errors = 'strict'
+        else:
+            errors = 'surrogateescape'
 
-def fs_encode(val):
-    encoding = sys.getfilesystemencoding()
-    if encoding == 'mbcs':
-        errors = 'strict'
-    else:
-        errors = 'surrogateescape'
-
-    if not isinstance(val, bytes):
-        return val.encode(encoding, errors)
-    else:
-        return val
+        if not isinstance(val, bytes):
+            return val.encode(encoding, errors)
+        else:
+            return val
 
 
 def _check_bytes(val):

--- a/xattr/lib.py
+++ b/xattr/lib.py
@@ -608,8 +608,14 @@ XATTR_RESOURCEFORK_NAME = "com.apple.ResourceFork"
 
 
 def fs_encode(val):
+    encoding = sys.getfilesystemencoding()
+    if encoding == 'mbcs':
+        errors = 'strict'
+    else:
+        errors = 'surrogateescape'
+
     if not isinstance(val, bytes):
-        return val.encode(sys.getfilesystemencoding())
+        return val.encode(encoding, errors)
     else:
         return val
 

--- a/xattr/tests/test_xattr.py
+++ b/xattr/tests/test_xattr.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from unittest import TestCase
+from unittest import TestCase, SkipTest
 from tempfile import mkdtemp, NamedTemporaryFile
 
 import xattr
@@ -88,6 +88,12 @@ class TestFile(TestCase, BaseTestXattr):
     def tearDown(self):
         self.tempfile.close()
 
+class TestFileWithSurrogates(TestFile):
+    def setUp(self):
+        if sys.platform != 'linux':
+            raise SkipTest('Files with invalid encoded names are only supported under linux')
+        self.tempfile = NamedTemporaryFile(prefix=b'invalid-\xe9'.decode('utf8','surrogateescape'))
+        self.tempfilename = self.tempfile.name
 
 class TestDir(TestCase, BaseTestXattr):
     def setUp(self):


### PR DESCRIPTION
If the other pull request is not acceptable for compatibility with older versions, here is one that copies the behaviour from the stdlib