### PR TITLE
Test for 'long' fd, used by FUSE

### DIFF
--- a/xattr/__init__.py
+++ b/xattr/__init__.py
@@ -53,7 +53,7 @@ class xattr(object):
         return "<%s %s=%r>" % (type(self).__name__, flavor, self.value)
 
     def _call(self, name_func, fd_func, *args):
-        if isinstance(self.value, int):
+        if isinstance(self.value, (int, long)):
             return fd_func(self.value, *args)
         else:
             return name_func(self.value, *args)


### PR DESCRIPTION
See http://stackoverflow.com/a/3501408/725021 for a complete explanation.
In FUSE, file handlers are given as long in my use case. This will enable the file handler to be recognized.