### PR TITLE
add fix for issue w/ lsattr and long attrs..

### DIFF
--- a/xattr/lib_build.py
+++ b/xattr/lib_build.py
@@ -60,7 +60,7 @@ static void convert_bsd_list(char *namebuf, size_t size)
 {
     size_t offset = 0;
     while(offset < size) {
-        int length = (int) namebuf[offset];
+        int length = (int) (unsigned char)namebuf[offset];
         memmove(namebuf+offset, namebuf+offset+1, length);
         namebuf[offset+length] = '\\0';
         offset += length+1;

--- a/xattr/lib_build.py
+++ b/xattr/lib_build.py
@@ -52,9 +52,7 @@ C_SRC = """
 #define XATTR_REPLACE 0x2
 
 /* Converts a freebsd format attribute list into a NULL terminated list.
- * While the man page on extattr_list_file says it is NULL terminated,
- * it is actually the first byte that is the length of the
- * following attribute.
+ * The first byte is the length of the following attribute.
  */
 static void convert_bsd_list(char *namebuf, size_t size)
 {


### PR DESCRIPTION
If the length of a FreeBSD attr is greater than 127, then this will result in a negative length causing a crash.  Fix this by casting to unsigned as it should be.