### PR TITLE
Always include `sys/types.h` when building lib.

### DIFF
--- a/xattr/lib_build.py
+++ b/xattr/lib_build.py
@@ -27,10 +27,10 @@ ssize_t xattr_flistxattr(int, char *, size_t, int);
 
 C_SRC = """
 #include "Python.h"
+#include <sys/types.h>
 #ifdef __FreeBSD__
 #include <sys/extattr.h>
 #elif defined(__SUN__) || defined(__sun__) || defined(__sun)
-#include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>


### PR DESCRIPTION
This change permits the use of BSD types (eg. `u_int32_t`) in Alpine and other POSIX compliant systems where they're not defined as standard.

As `sys/types.h` is defined in the [POSIX library](http://www.opengroup.org/onlinepubs/9699919799/idx/head.html) this should be fully compatible with all supported operating systems.