### PR TITLE
Include .c and .h files in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 include *.py
+include *.c
+include *.h
 include *.txt
 include MANIFEST.in
 include xattr/tests/*.py


### PR DESCRIPTION
It's my fault for forgetting this in #70, by not doing a build test.
This breaks the 0.9.4 release, so this is kinda awful.
Probably requires a new release asap.

Thanks to @novel for noticing this [here](https://github.com/xattr/xattr/commit/ffeccb067de52fa6296d9063dec5897a2a79ecea#commitcomment-29898303).
