### PR TITLE
Add subdirectory for C source files to `MANIFEST.in`.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include *.py
-include *.c
-include *.h
+include xattr/*.c
+include xattr/*.h
 include *.txt
 include MANIFEST.in
 include xattr/tests/*.py


### PR DESCRIPTION
@nyov's `MANIFEST.in` fixes in  #77 still don't pick up the C source files, resulting in an error when installing from the tarball - I've added the subdirectory to fix.

I'm sorting out Travis tests to make sure this doesn't happen again just now.