### PR TITLE
setup.py: make CLASSIFIERS a list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ Extended attributes are currently only available on Darwin 8.0+ (Mac OS X 10.4)
 and Linux 2.6+. Experimental support is included for Solaris and FreeBSD.
 """
 
-CLASSIFIERS = filter(bool, map(str.strip,
+CLASSIFIERS = list(filter(bool, map(str.strip,
 """
 Environment :: Console
 Intended Audience :: Developers
@@ -29,7 +29,7 @@ Programming Language :: Python
 Programming Language :: Python :: 2
 Programming Language :: Python :: 3
 Topic :: Software Development :: Libraries :: Python Modules
-""".splitlines()))
+""".splitlines())))
 
 setup(
     name="xattr",


### PR DESCRIPTION
This fixes:

Warning: 'classifiers' should be a list, got type 'filter'

during setup.py run if python is python3.