### PR TITLE
Remove exec flag from tool.py

### DIFF
--- a/xattr/tool.py
+++ b/xattr/tool.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 ##
 # Copyright (c) 2007 Apple Inc.
 #


### PR DESCRIPTION
tool.py is only intended to be executed through the xattr wrapped generated during package build.
Thus tool.py should not have the executable flag set, and should not have a shebang line.