### PR TITLE
Fix use with nuitka

### DIFF
--- a/xattr/lib.py
+++ b/xattr/lib.py
@@ -1,7 +1,8 @@
 import os
 import sys
 
-from ._lib import lib, ffi
+import _cffi_backend # noqa: F401  # required by _lib
+from ._lib import lib, ffi # type: ignore
 
 XATTR_NOFOLLOW = lib.XATTR_XATTR_NOFOLLOW
 XATTR_CREATE = lib.XATTR_XATTR_CREATE


### PR DESCRIPTION
When using this python library in a program that compiles with nuitka it will error out with a `_cffi_backend not found` message. This is because python-cffi loads the backend dynamically and the nuitka resolver is not able to determine that it should be included in the binary.

Fix this by creating an explicit import and adding annotations so that linting tools will ignore the "unused" dependency here.