### PR TITLE
#129 support optional default value in xattr.get()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 .DS_Store
 /.vscode
 .venv
+uv.lock

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 __pycache__
 .DS_Store
 /.vscode
+.venv

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 Version 1.2.0 released 2025-07-XX
 
 * Support optional default value in xattr.get()
-  https://github.com/xattr/xattr/pull/131
+  https://github.com/xattr/xattr/pull/130
 * Ignore macOS 13 SIP attribute 'com.apple.provenance' in tests
   https://github.com/xattr/xattr/pull/131
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,9 @@
 Version 1.2.0 released 2025-07-XX
 
+* Support optional default value in xattr.get()
+  https://github.com/xattr/xattr/pull/131
 * Ignore macOS 13 SIP attribute 'com.apple.provenance' in tests
-  https://github.com/xattr/xattr/pull/130
+  https://github.com/xattr/xattr/pull/131
 
 Version 1.1.4 released 2025-01-06
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,12 @@ authors = [
 maintainers = [
     {name = "Bob Ippolito", email = "bob@redivi.com"},
 ]
-description="Python wrapper for extended filesystem attributes"
-license = { file = "LICENSE.txt" }
+description = "Python wrapper for extended filesystem attributes"
+license = "MIT"
 keywords = ["xattr"]
 classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,13 @@ authors = [
 maintainers = [
     {name = "Bob Ippolito", email = "bob@redivi.com"},
 ]
-description = "Python wrapper for extended filesystem attributes"
-license = "MIT"
+description="Python wrapper for extended filesystem attributes"
+license = { file = "LICENSE.txt" }
 keywords = ["xattr"]
 classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux",

--- a/tests/test_xattr.py
+++ b/tests/test_xattr.py
@@ -117,6 +117,34 @@ class BaseTestXattr(object):
         # Test that listing with pyxattr_compat does not prefix or decode
         self.assertEqual(pyxattr_compat.list(self.tempfile), [b'test'])
 
+    def test_get_with_default(self):
+        x = xattr.xattr(self.tempfile)
+
+        # Test backwards compatibility - exception raised when no default
+        with self.assertRaises(OSError):
+            x.get('user.nonexistent')
+
+        # Test default=None returns None
+        result = x.get('user.nonexistent', default=None)
+        self.assertIsNone(result)
+
+        # Test default parameter with non-None values
+        result = x.get('user.nonexistent', default=b'default_value')
+        self.assertEqual(result, b'default_value')
+
+        # Test default parameter with empty string
+        result = x.get('user.nonexistent', default=b'')
+        self.assertEqual(result, b'')
+
+        # Test that existing attributes ignore default
+        x['user.existing'] = b'real_value'
+        result = x.get('user.existing', default=b'should_be_ignored')
+        self.assertEqual(result, b'real_value')
+
+        # Test that default is keyword-only (positional should fail)
+        with self.assertRaises(TypeError):
+            x.get('user.nonexistent', 0, b'default_value')
+
 
 class TestFile(TestCase, BaseTestXattr):
     def setUp(self):

--- a/tests/test_xattr.py
+++ b/tests/test_xattr.py
@@ -35,13 +35,13 @@ class BaseTestXattr(object):
             d['SUNWattr_ro'] = x['SUNWattr_ro']
             d['SUNWattr_rw'] = x['SUNWattr_rw']
 
-        # SELinux systems use an attribute which must be accounted for
-        if sys.platform.startswith('linux') and 'security.selinux' in x:
-            d['security.selinux'] = x['security.selinux']
-
         # macOS 13.x SIP adds this attribute to all files
-        if x.has_key('com.apple.provenance'):
-            d['com.apple.provenance'] = x['com.apple.provenance']
+        # POSIX platforms may have system.posix_acl_default
+        # SELinux systems use an attribute which must be accounted for
+        IGNORE_KEYS = ['com.apple.provenance', 'system.posix_acl_default', 'security.selinux']
+        for k in IGNORE_KEYS:
+            if x.has_key(k):
+                d[k] = x[k]
 
         self.assertEqual(list(x.keys()), list(d.keys()))
         self.assertEqual(list(x.list()), list(d.keys()))

--- a/xattr/__init__.py
+++ b/xattr/__init__.py
@@ -26,6 +26,11 @@ __all__ = [
 
 
 _SENTINEL_MISSING = object()
+ERRNO_MISSING = set()
+try:
+    ERRNO_MISSING.add(errno.ENOATTR)
+except AttributeError:
+    ERRNO_MISSING.add(errno.ENODATA)
 
 
 class xattr(object):
@@ -74,7 +79,7 @@ class xattr(object):
         try:
             return self._call(_getxattr, _fgetxattr, name, 0, 0, options | self.options)
         except OSError as e:
-            if default is not _SENTINEL_MISSING and e.errno == errno.ENOATTR:
+            if default is not _SENTINEL_MISSING and e.errno in ERRNO_MISSING:
                 return default
             raise
 

--- a/xattr/__init__.py
+++ b/xattr/__init__.py
@@ -74,7 +74,7 @@ class xattr(object):
         try:
             return self._call(_getxattr, _fgetxattr, name, 0, 0, options | self.options)
         except OSError as e:
-            if errno.ENOATTR in str(e) and default is not _SENTINEL_MISSING:
+            if default is not _SENTINEL_MISSING and e.errno == errno.ENOATTR:
                 return default
             raise
 

--- a/xattr/__init__.py
+++ b/xattr/__init__.py
@@ -9,6 +9,8 @@ that exposes these extended attributes.
 
 __version__ = '1.1.4'
 
+import errno
+
 from .lib import (XATTR_NOFOLLOW, XATTR_CREATE, XATTR_REPLACE,
     XATTR_NOSECURITY, XATTR_MAXNAMELEN, XATTR_FINDERINFO_NAME,
     XATTR_RESOURCEFORK_NAME, XATTR_COMPAT_USER_PREFIX,
@@ -21,6 +23,9 @@ __all__ = [
     "XATTR_MAXNAMELEN", "XATTR_FINDERINFO_NAME", "XATTR_RESOURCEFORK_NAME",
     "xattr", "listxattr", "getxattr", "setxattr", "removexattr"
 ]
+
+
+_SENTINEL_MISSING = object()
 
 
 class xattr(object):
@@ -59,14 +64,19 @@ class xattr(object):
         else:
             return name_func(self.value, *args)
 
-    def get(self, name, options=0):
+    def get(self, name, options=0, *, default=_SENTINEL_MISSING):
         """
         Retrieve the extended attribute ``name`` as a ``str``.
-        Raises ``IOError`` on failure.
+        Raises ``IOError`` on failure unless default is provided.
 
         See x-man-page://2/getxattr for options and possible errors.
         """
-        return self._call(_getxattr, _fgetxattr, name, 0, 0, options | self.options)
+        try:
+            return self._call(_getxattr, _fgetxattr, name, 0, 0, options | self.options)
+        except OSError as e:
+            if errno.ENOATTR in str(e) and default is not _SENTINEL_MISSING:
+                return default
+            raise
 
     def set(self, name, value, options=0):
         """


### PR DESCRIPTION
Closes #129 

Support default value on get.

~NOTE: Currently, if the user passes `default=None`, this still throws an Error. Alternatively, we could create a sentinel value to also accept `None`. I think that'd be a good idea.~

`None` is accepted as an explicit default value.