### PR TITLE
Ignore macOS 13 SIP attribute 'com.apple.provenance' in tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+Version 1.2.0 released 2025-07-XX
+
+* Ignore macOS 13 SIP attribute 'com.apple.provenance' in tests
+  https://github.com/xattr/xattr/pull/130
+
 Version 1.1.4 released 2025-01-06
 
 * Update GitHub actions to support upload-artifact@v4 (with the side-effect of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 requires-python = ">= 3.8"
 name = "xattr"
-version = "1.1.4"
+version = "1.2.0"
 readme = "README.rst"
 dependencies = [
     "cffi>=1.16.0",

--- a/tests/test_xattr.py
+++ b/tests/test_xattr.py
@@ -39,6 +39,10 @@ class BaseTestXattr(object):
         if sys.platform.startswith('linux') and 'security.selinux' in x:
             d['security.selinux'] = x['security.selinux']
 
+        # macOS 13.x SIP adds this attribute to all files
+        if x.has_key('com.apple.provenance'):
+            d['com.apple.provenance'] = x['com.apple.provenance']
+
         self.assertEqual(list(x.keys()), list(d.keys()))
         self.assertEqual(list(x.list()), list(d.keys()))
         self.assertEqual(dict(x), d)
@@ -94,7 +98,9 @@ class BaseTestXattr(object):
                 # Solaris, Linux don't support extended attributes on symlinks
                 raise unittest.SkipTest("XATTRs on symlink not allowed"
                                         " on filesystem/platform")
-            self.assertEqual(dict(realfile), {})
+            realfile_xattrs = dict(realfile)
+            realfile_xattrs.pop('com.apple.provenance', None)
+            self.assertEqual(realfile_xattrs, {})
             self.assertEqual(symlink['user.islink'], b'true')
         finally:
             os.remove(symlinkPath)

--- a/xattr/__init__.py
+++ b/xattr/__init__.py
@@ -7,7 +7,7 @@ The xattr type wraps a path or file descriptor with a dict-like interface
 that exposes these extended attributes.
 """
 
-__version__ = '1.1.4'
+__version__ = '1.2.0'
 
 from .lib import (XATTR_NOFOLLOW, XATTR_CREATE, XATTR_REPLACE,
     XATTR_NOSECURITY, XATTR_MAXNAMELEN, XATTR_FINDERINFO_NAME,


### PR DESCRIPTION
#130 noted that the tests do not pass as-is on macOS 13, this should resolve that issue